### PR TITLE
adding sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ node kinesify-data.js event.unencoded.sierra_bib_post_request.json event.json ht
 
 This will take the un-encoded data in `event.unencoded.bibs.json` and put it in a kinesis stream format using the avro schema. You can load items by replacing the input file with `event.unencoded.items.json`
 
-Assuming you have the proper API and oauth credentials setup in your `.env`, you can run the lambda locally using the mock data in `events.json`
+Assuming you have the proper API and oauth credentials setup in your `.env`, you can run the lambda locally using the mock data in `event.json`
 
 ```
 node-lambda run
 ```
 
-This will take `events.json` (which is mocked-up kinesis stream data) as input, authenticate with oauth server, retrieve schema from Schema API, parse stream data, then post it to the bib or item API depending on config.
+This will take `event.json` (which is mocked-up kinesis stream data) as input, authenticate with oauth server, retrieve schema from Schema API, parse stream data, then post it to the bib or item API depending on config.
 
 ## Deploy
 
@@ -51,6 +51,8 @@ NYPL_API_POST_URL=xxx
 NYPL_API_SCHEMA_URL=xxx
 NYPL_POST_TYPE=xxx
 ```
+
+Update event.json by running the above kinesify-data.js script for either item or bib.  
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NYPL_OAUTH_KEY=xxx
 NYPL_OAUTH_SECRET=xxx
 NYPL_API_POST_URL=xxx
 NYPL_API_SCHEMA_URL=xxx
+NYPL_POST_TYPE=xxx
 ```
 
 `NYPL_API_POST_URL` is the API URL you will be posting to. So this can be configured to be the bib or item endpoint. Similarly with `NYPL_API_SCHEMA_URL`, you can configure this to be bib or item schema.
@@ -48,6 +49,7 @@ NYPL_OAUTH_KEY=xxx
 NYPL_OAUTH_SECRET=xxx
 NYPL_API_POST_URL=xxx
 NYPL_API_SCHEMA_URL=xxx
+NYPL_POST_TYPE=xxx
 ```
 
 Then run:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const OAuth = require('oauth')
 const Promise = require('promise')
 const request = require('request')
 
+const defaultNyplSource = 'sierra-nypl'
+
 // Initialize cache
 var CACHE = {}
 
@@ -48,7 +50,7 @@ exports.kinesisHandler = function (records, context, callback) {
 
   function addSource (record) {
     console.log('Adding source')
-    record['nyplSource'] = 'sierra-nypl'
+    record['nyplSource'] = defaultNyplSource
     record['nyplType'] = process.env['NYPL_POST_TYPE']
     return record
   }
@@ -67,17 +69,16 @@ exports.kinesisHandler = function (records, context, callback) {
     request(options, function (error, response, body) {
       console.log('Posting...')
       if (error || body.errors && body.errors.length) {
+        console.log(body.errors)
         if (error) {
           console.log('Error! ' + error)
           callback(new Error(error))
         } else {
-          console.log('Error! ' + body.errors[0])
-          callback(new Error(body.errors[0]))
+          console.log('Error! ' + body.errors)
+          callback(new Error(body.errors))
         }
-        context.fail()
       } else {
         callback(null, 'POST Success')
-        context.succeed()
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ exports.kinesisHandler = function (records, context, callback) {
     })
   }
 
-  function schema() {
+  function schema () {
     // schema in cache; just return it as a instant promise
     if (CACHE['schema']) {
       console.log('Already have schema')

--- a/index.js
+++ b/index.js
@@ -28,10 +28,11 @@ exports.kinesisHandler = function (records, context, callback) {
     // parse payload
     var records = payload
       .map(function (record) {
-        return parseKinesis(record, avroType)
+        return addSource(parseKinesis(record, avroType))
       })
     // post to API
     console.log('Posting records')
+    console.log(records)
     postRecords(accessToken, records)
   }
 
@@ -42,6 +43,13 @@ exports.kinesisHandler = function (records, context, callback) {
     var buf = new Buffer(payload.kinesis.data, 'base64')
     // decode avro
     var record = avroType.fromBuffer(buf)
+    return record
+  }
+
+  function addSource (record) {
+    console.log('Adding source')
+    record['nyplSource'] = 'sierra-nypl'
+    record['nyplType'] = process.env['NYPL_POST_TYPE']
     return record
   }
 

--- a/index.js
+++ b/index.js
@@ -1,138 +1,147 @@
-console.log('Loading Discovery Bib Poster');
+console.log('Loading Discovery Bib Poster')
 
-const avro = require('avsc');
-const OAuth = require('oauth');
-const Promise = require('promise');
-const request = require('request');
+const avro = require('avsc')
+const OAuth = require('oauth')
+const Promise = require('promise')
+const request = require('request')
 
 // Initialize cache
-var CACHE = {};
+var CACHE = {}
 
 // kinesis stream handler
-exports.kinesisHandler = function(records, context, callback) {
-  console.log('Processing ' + records.length + ' records');
+exports.kinesisHandler = function (records, context, callback) {
+  console.log('Processing ' + records.length + ' records')
 
   // retrieve token and schema
   Promise.all([token(), schema()])
     .then(function (res) {
-      var access_token = res[0];
-      var schema = res[1];
-      onReady(records, access_token, schema);
-    });
+      var accessToken = res[0]
+      var schema = res[1]
+      onReady(records, accessToken, schema)
+    })
 
   // run when access token and schema are loaded
-  function onReady(payload, access_token, schema) {
-    // console.log('Ready', access_token, schema);
+  function onReady (payload, accessToken, schema) {
+    console.log('Ready', accessToken, schema)
     // load avro schema
-    var avroType = avro.parse(schema);
+    var avroType = avro.parse(schema)
     // parse payload
-    var data = payload
-      .map(function(record){
-        return parseKinesis(record, avroType);
-      });
+    var records = payload
+      .map(function (record) {
+        return parseKinesis(record, avroType)
+      })
     // post to API
-    postRecords(access_token, data);
+    console.log('Posting records')
+    postRecords(accessToken, records)
   }
 
   // map to records objects as needed
-  function parseKinesis(payload, avroType) {
+  function parseKinesis (payload, avroType) {
+    console.log('Parsing Kinesis')
     // decode base64
-    var buf = new Buffer(payload.kinesis.data, 'base64');
+    var buf = new Buffer(payload.kinesis.data, 'base64')
     // decode avro
-    var record = avroType.fromBuffer(buf);
-    return record;
+    var record = avroType.fromBuffer(buf)
+    return record
   }
 
   // bulk posts records
-  function postRecords(access_token, records) {
+  function postRecords (accessToken, records) {
     var options = {
       uri: process.env['NYPL_API_POST_URL'],
       method: 'POST',
-      headers: { Authorization: `Bearer ${access_token}` },
+      headers: { Authorization: `Bearer ${accessToken}` },
       body: records,
       json: true
-    };
+    }
 
     // POST request
-    request(options, function(error, response, body){
+    request(options, function (error, response, body) {
+      console.log('Posting...')
       if (error || body.errors && body.errors.length) {
         if (error) {
-          callback(new Error(error));
+          console.log('Error! ' + error)
+          callback(new Error(error))
         } else {
-          callback(new Error(body.errors[0]));
+          console.log('Error! ' + body.errors[0])
+          callback(new Error(body.errors[0]))
         }
-        // context.fail();
-
+        context.fail()
       } else {
-        callback(null, "POST Success");
-        // context.succeed();
+        callback(null, 'POST Success')
+        context.succeed()
       }
-    });
+    })
   }
 
   function schema() {
     // schema in cache; just return it as a instant promise
     if (CACHE['schema']) {
-      console.log('Already have schema');
-      return new Promise(function(resolve, reject){
-        resolve(CACHE['schema']);
-      });
+      console.log('Already have schema')
+      return new Promise(function (resolve, reject) {
+        resolve(CACHE['schema'])
+      })
     }
 
     return new Promise(function (resolve, reject) {
       var options = {
         uri: process.env['NYPL_API_SCHEMA_URL'],
         json: true
-      };
-      console.log('Loading schema...');
-      request(options, function(error, resp, body){
+      }
+      console.log('Loading schema...')
+      request(options, function (error, resp, body) {
         if (error) {
-          reject(error);
+          console.log('Error! ' + error)
+          reject(error)
         }
         if (body.data && body.data.schema) {
-          console.log('Sucessfully loaded schema');
-          var schema = JSON.parse(body.data.schema);
-          CACHE['schema'] = schema;
-          resolve(schema);
+          console.log('Sucessfully loaded schema')
+          var schema = JSON.parse(body.data.schema)
+          CACHE['schema'] = schema
+          resolve(schema)
+        } else {
+          reject()
         }
-        else {
-          reject();
-        }
-      });
-    });
+      })
+    })
   }
 
   // oauth token retriever
-  function token() {
+  function token () {
     // access token in cache; just return it as a instant promise
-    if (CACHE['access_token']) {
-      console.log('Already authenticated');
-      return new Promise(function(resolve, reject){
-        resolve(CACHE['access_token']);
-      });
+    if (CACHE['accessToken']) {
+      console.log('Already authenticated')
+      return new Promise(function (resolve, reject) {
+        resolve(CACHE['accessToken'])
+      })
     }
 
     // request a new token
-    console.log('Requesting new token...');
+    console.log('Requesting new token...')
     return new Promise(function (resolve, reject) {
-      var OAuth2 = OAuth.OAuth2;
-      var key = process.env['NYPL_OAUTH_KEY'];
-      var secret = process.env['NYPL_OAUTH_SECRET'];
-      var url = process.env['NYPL_OAUTH_URL'];
-      var auth = new OAuth2(key, secret, url, null, 'oauth/token', null);
-      auth.getOAuthAccessToken('', { grant_type: 'client_credentials' }, function(e, access_token, refresh_token, results) {
-        console.log('Successfully authenticated');
-        CACHE['access_token'] = access_token;
-        resolve(access_token);
-      });
-    });
+      var OAuth2 = OAuth.OAuth2
+      var key = process.env['NYPL_OAUTH_KEY']
+      var secret = process.env['NYPL_OAUTH_SECRET']
+      var url = process.env['NYPL_OAUTH_URL']
+      var auth = new OAuth2(key, secret, url, null, 'oauth/token', null)
+      auth.getOAuthAccessToken('', { grant_type: 'client_credentials' }, function (error, accessToken, refreshToken, results) {
+        if (error) {
+          reject(error)
+          console.log('Not authenticated')
+        } else {
+          console.log('Successfully authenticated')
+          CACHE['accessToken'] = accessToken
+          resolve(accessToken)
+        }
+      })
+    })
   }
-};
+}
 
 // main function
-exports.handler = function(event, context, callback) {
-  var record = event.Records[0];
+exports.handler = function (event, context, callback) {
+  var record = event.Records[0]
   if (record.kinesis) {
-    exports.kinesisHandler(event.Records, context, callback);
+    exports.kinesisHandler(event.Records, context, callback)
   }
-};
+}

--- a/kinesify-data.js
+++ b/kinesify-data.js
@@ -1,38 +1,38 @@
 // Usage:
 //  The following command will take unencoded json, encode it with avro schema, encode it with base64, and put in Kinesis format.
-//    node kinesify-data.js event.unencoded.bibs.json event.json https://api.nypltech.org/api/v0.1/current-schemas/Bib
+//    node kinesify-data.js event.unencoded.sierra_bib_post_request.json event.json https://api.nypltech.org/api/v0.1/current-schemas/Bib
 
-const args = process.argv.slice(2);
-const avro = require('avsc');
-const fs = require('fs');
-const request = require('request');
+const args = process.argv.slice(2)
+const avro = require('avsc')
+const fs = require('fs')
+const request = require('request')
 
 // config
-const infile = args[0];
-const outfile = args[1];
-const schemaUrl = args[2];
+const infile = args[0]
+const outfile = args[1]
+const schemaUrl = args[2]
 
 function onSchemaLoad(schema){
   // initialize avro schema
-  var avroType = avro.parse(schema);
+  var avroType = avro.parse(schema)
 
   // read unencoded data
-  var unencodedData = JSON.parse(fs.readFileSync(infile, 'utf8'));
+  var unencodedData = JSON.parse(fs.readFileSync(infile, 'utf8'))
 
   // encode data and put in kinesis format
   var kinesisEncodedData = unencodedData.Records
     .map(function(record){
-      return kinesify(record, avroType);
+      return kinesify(record, avroType)
     });
 
   // stringify and write to file
-  var json = JSON.stringify({"Records": kinesisEncodedData}, null, 2);
+  var json = JSON.stringify({"Records": kinesisEncodedData}, null, 2)
   fs.writeFile(outfile, json, 'utf8', function(err, data){
     if (err) {
-      console.log('Write error:', err);
+      console.log('Write error:', err)
 
     } else {
-      console.log('Successfully wrote data to file');
+      console.log('Successfully wrote data to file')
     }
   });
 }
@@ -67,8 +67,8 @@ var options = {
 };
 request(options, function(error, resp, body){
   if (body.data && body.data.schema) {
-    console.log('Loaded schema');
-    var schema = JSON.parse(body.data.schema);
-    onSchemaLoad(schema);
+    console.log('Loaded schema')
+    var schema = JSON.parse(body.data.schema)
+    onSchemaLoad(schema)
   }
 });


### PR DESCRIPTION
This PR seeks to update bib/item poster with nyplSource and nyplType.

Why does it look so busy? Because I also refactored to comply with JS Stanard formatting. That is the one we are going with moving forward, right? But if you don't care about that, you can look at the commit specific to changes.

For now we are hardcoding nypl-sierra. This can change when it needs to change and become smarter. There's a new .env variable that asserts whether the record is an item or a bib -- since that is also what we do with whether something is going down the item path or the bib path for posting. Since this app is a 2-fer-1.